### PR TITLE
feat: Introduce local mode for integration test in CI

### DIFF
--- a/cmd/azure-keyvault-controller/main.go
+++ b/cmd/azure-keyvault-controller/main.go
@@ -196,6 +196,12 @@ func main() {
 			klog.ErrorS(err, "failed to create credentials provider from azidentity for azure key vault")
 			os.Exit(1)
 		}
+	case "local":
+		token, keyVaultDNSSuffix, err = getLocalCredentials()
+		if err != nil {
+			klog.ErrorS(err, "failed to create dummy credentials provider from local environment")
+			os.Exit(1)
+		}
 
 	default:
 		klog.ErrorS(nil, "auth type not supported", "type", authType)
@@ -300,4 +306,17 @@ func getCredentialsFromAzidentity() (azure.LegacyTokenCredential, string, error)
 	}
 
 	return token, provider.GetAzureKeyVaultDNSSuffix(), err
+}
+
+func getLocalCredentials() (azure.LegacyTokenCredential, string, error) {
+	provider, err := credentialprovider.FakeEnvironmentCredentialProvider()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create azure identity provider, error: %+v", err)
+	}
+	token, err := provider.GetAzureKeyVaultCredentials()
+	if err != nil {
+		return nil, "", nil
+	}
+
+	return token, "local", err
 }

--- a/pkg/azure/keyvault/client/service.go
+++ b/pkg/azure/keyvault/client/service.go
@@ -74,6 +74,10 @@ func (a *azureKeyVaultService) GetSecret(vaultSpec *akvs.AzureKeyVault) (string,
 		return "", fmt.Errorf("azurekeyvaultsecret.spec.vault.object.name not set")
 	}
 
+	if a.keyVaultDNSSuffix == "local" {
+		return "dummy", nil
+	}
+
 	client, err := azsecrets.NewClient(a.vaultNameToURL(vaultSpec.Name), a.credentials, nil)
 	if err != nil {
 		return "", err
@@ -92,6 +96,10 @@ func (a *azureKeyVaultService) GetSecret(vaultSpec *akvs.AzureKeyVault) (string,
 func (a *azureKeyVaultService) GetKey(vaultSpec *akvs.AzureKeyVault) (string, error) {
 	if vaultSpec.Object.Name == "" {
 		return "", fmt.Errorf("azurekeyvaultsecret.spec.vault.object.name not set")
+	}
+
+	if a.keyVaultDNSSuffix == "local" {
+		return "dummy", nil
 	}
 
 	client, err := azkeys.NewClient(a.vaultNameToURL(vaultSpec.Name), a.credentials, nil)


### PR DESCRIPTION
Introduce `local` mode for akv2k8s controller, the purpose of this operation is for testing readiness of an application in a local cluster where we don't need to pull real secrets

When using 
```yaml
global:
  keyVaultAuth: local
```

The controller will not attempt to create an az client to pull the AKV secret, it will generate the secret with `dummy` value.
